### PR TITLE
added forceFetch, options to findAll, empty() function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ bookStore.find(1).then(model => {
   model.get('name'); // >> A Tale of Two Cities
 });
 ```
+You can optionally pass a boolean forceFetch to ensure a call is made to the backend. Default is false.
+```js
+bookStore.find(1, true);
+```
 
 ### `findAll`
 
@@ -51,6 +55,19 @@ collection has not previously been synced it will call the collection's
 bookStore.findAll().then(collection => {
   collection.length; // >> 10
 });
+```
+
+Allows a object 'options' that will get passed to the collection fetch call.
+```js
+bookStore.findAll({
+  data: { sortBy: 'name' }
+}).then(collection => {
+  collection.length; // >> 10
+});
+```
+You can optionally pass a boolean forceFetch to ensure a call is made to the backend. Default is false.
+```js
+bookStore.findAll({}, true);
 ```
 
 ### `save`

--- a/src/backbone.storage.js
+++ b/src/backbone.storage.js
@@ -64,11 +64,13 @@ var Storage = Backbone.Storage = Metal.Class.extend({
    * @method find
    * @memberOf Storage
    * @param {Number|String|Object|Backbone.Model} model - The model to find.
+   * @param {Boolean} forceFetch - Force fetch model from server.
    * @returns {Promise} - A promise that will resolve to the model.
    */
-  find(model) {
+  find(model, forceFetch = false) {
     let record = this.records.get(model);
-    if (record) {
+
+    if (record && !forceFetch) {
       return Promise.resolve(record);
     } else {
       model = this._ensureModel(model);
@@ -86,13 +88,16 @@ var Storage = Backbone.Storage = Metal.Class.extend({
    * @instance
    * @method findAll
    * @memberOf Storage
+   * @param {Object} options - Options to pass to collection fetch. Also allows
+   * setting parameters on collection.
+   * @param {Boolean} forceFetch - Force fetch model from server.
    * @returns {Promise} - A promise that will resolve to the entire collection.
    */
-  findAll() {
-    if (this._hasSynced) {
+  findAll(options = {}, forceFetch = false) {
+    if (this._hasSynced && !forceFetch) {
       return Promise.resolve(this.records);
     } else {
-      return Promise.resolve(this.records.fetch()).then(() => {
+      return Promise.resolve(this.records.fetch(options)).then(() => {
         return this.records;
       });
     }
@@ -130,7 +135,7 @@ var Storage = Backbone.Storage = Metal.Class.extend({
    * @returns {Promise} - A promise that will resolve to the added model.
    */
   insert(model) {
-    model = this.records.add(model);
+    model = this.records.add(model, { merge: true });
     return Promise.resolve(model);
   },
 

--- a/test/unit/storage.js
+++ b/test/unit/storage.js
@@ -21,6 +21,15 @@ describe('Storage', function() {
       });
     });
 
+    it('should call fetch when forceFetch is true', function() {
+      var self = this;
+      return this.storage.find(2).then(function() {
+        return self.storage.find(2, true);
+      }).then(function() {
+        expect(Backbone.Model.prototype.fetch).to.have.been.calledTwice;
+      });
+    });
+
     describe('by id', function() {
       it('should return the record if it exists', function() {
         var self = this;
@@ -105,12 +114,35 @@ describe('Storage', function() {
       });
     });
 
+    it('should call fetch when forceFetch is true', function() {
+      var self = this;
+      return this.storage.findAll().then(function() {
+        return self.storage.findAll({}, true);
+      }).then(function() {
+        expect(Backbone.Collection.prototype.fetch).to.have.been.calledTwice;
+      });
+    });
+
     it('should fetch the collection if it has not been fetched', function() {
       var self = this;
       return this.storage.findAll().then(function(collection) {
         expect(collection.length).to.equal(2);
         expect(collection).to.equal(self.storage.records);
         expect(Backbone.Collection.prototype.fetch).to.have.been.called;
+      });
+    });
+
+    it('should add data parameters on collection url if set in findAll', function() {
+      return this.storage.findAll({
+        data: {
+          sortBy: 'name'
+        }
+      }).then(function() {
+        expect(Backbone.Collection.prototype.fetch).to.have.been.calledWith({
+          data: {
+            sortBy: 'name'
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
This pullrequest adds the following:
- forceFetch param to find(). This allows you to force a call to the backend, even if the model already exists in the storage. I use this for when the model in a previous call does not contain all information of the model. Like when you go from list-view to show-view.
- Passes options to fetch method in findAll. This allows you to add GET-parameters by passing 'data'. Also allows the 'parameters' key that gets added to the collection. This allows for dynamic urls. See readme.
- Adds empty method to allow emptying the storage.

Let me know what you think and if I should improve some stuff.
The test I wrote for the GET-parameters isn't great, but I wasn't sure how to make it better.
